### PR TITLE
Fixing crowded Footer

### DIFF
--- a/data.js
+++ b/data.js
@@ -82,13 +82,8 @@ document.write('</div>');
 }
    }
 document.write('</table>');
-
-
     
       document.write('</div>');
-document.write('<a href="http://thenounproject.com/noun/clock/#icon-No3020" target="_blank">Clock</a> designed by <a href="http://thenounproject.com/NicholasBurroughs" target="_blank">Nicholas Burroughs</a> from The Noun Project.');
-document.write('<br>');
-document.write('Made with a lot of love using <a href="http://getbootstrap.com/" target="_blank">Bootstrap.</a>');
 
 function secondsToTime(secs)
 {

--- a/statistics.html
+++ b/statistics.html
@@ -7,15 +7,16 @@
 </head>
 
 <body>
-	
+
 <a href="https://github.com/pkarthikr/Webby-Tracker"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
 
   <div class="container">
 
-	<p>© Webby Tracker - Made by <a href="http://www.pkarthik.in">Karthik Ragubathy</a></p>
-	<p>Send feature requests to <a href="mailto:me@pkarthik.in">me@pkarthik.in</a></p>
-	<p>Source code at <a href="https://github.com/pkarthikr/Webby-Tracker">Github</a></p>
-	<p>If you do not see anything on this page - Browse around for some time and check back</p>
+
+<a href="http://thenounproject.com/noun/clock/#icon-No3020" target="_blank">Clock icon</a> by <a href="http://thenounproject.com/NicholasBurroughs" target="_blank">Nicholas Burroughs</a>.
+<br>
+	<p>Made by <a href="http://www.pkarthik.in">Karthik Ragubathy. </a>Send feature requests to <a href="mailto:me@pkarthik.in">me@pkarthik.in</a></p>
+	
 
 </div>
   </body>


### PR DESCRIPTION
Shortened text to make for a crisp and short footer. Removed copyright
symbol, as it's an opensource project. Removed source on Github link as
we now have a banner for that on Top-Right.

Also removed 'If you don't see anything' message as it should only be
shown when there is nothing to see, not always.
